### PR TITLE
ci: add SwiftPM build & test on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    name: Build and Test (SwiftPM)
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Build
+        run: swift build --configuration debug
+
+      - name: Run tests
+        run: swift test --parallel --enable-code-coverage --verbosity detailed


### PR DESCRIPTION
This adds a GitHub Actions workflow to build and run tests for the Swift Package using SwiftPM on macOS 14 / Xcode 15.4.

- Builds with 
- Runs tests with  (parallel + coverage)
- Caches SwiftPM and DerivedData for faster runs

Triggers on pushes and PRs to .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated build and test workflow for the main branch using GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->